### PR TITLE
Add condition value reference syntax

### DIFF
--- a/tests/quick-function.test.ts
+++ b/tests/quick-function.test.ts
@@ -32,5 +32,11 @@ describe('quickFunction', () => {
 
       expect(formatter({ value: false })).toBe('test is successful');
     });
+
+    it('should inject reference to condition value', () => {
+      const formatter = quickFunction<TestArg>`test #?:${(arg) => arg.value}is #$ so it ?#is successful`;
+
+      expect(formatter({ value: true })).toBe('test is true so it is successful');
+    });
   });
 });

--- a/tests/quick-string.test.ts
+++ b/tests/quick-string.test.ts
@@ -14,5 +14,9 @@ describe('quickString', () => {
     it('should inject text between #? and ?# has given value is falsy', () => {
       expect(quickString`test #?:${false}is so cool that it ?#is successful`).toBe('test is successful');
     });
+
+    it('should inject reference to condition value', () => {
+      expect(quickString`test #?:${true}is #$ so it ?#is successful`).toBe('test is true so it is successful');
+    });
   });
 });


### PR DESCRIPTION
Adding `#$` inside a condition will be replaced by the tested value